### PR TITLE
Fix PR #1 review findings: FTS5 injection, error context, DB safety

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -52,10 +52,17 @@ function initDb(db: Database.Database): void {
 }
 
 let _db: Database.Database | null = null;
+let _dbPath: string | null = null;
 
 export function getDb(dbPath?: string): Database.Database {
-  if (_db) return _db;
   const path = dbPath ?? process.env.ALEXANDRIA_DB_PATH ?? './alexandria.db';
+  if (_db) {
+    if (_dbPath !== path) {
+      throw new Error(`Database already open at "${_dbPath}", cannot open "${path}". Call closeDb() first.`);
+    }
+    return _db;
+  }
+  _dbPath = path;
   _db = new Database(path);
   initDb(_db);
   return _db;
@@ -63,8 +70,10 @@ export function getDb(dbPath?: string): Database.Database {
 
 export function closeDb(): void {
   if (_db) {
-    _db.close();
+    const db = _db;
     _db = null;
+    _dbPath = null;
+    db.close();
   }
 }
 


### PR DESCRIPTION
## Summary

Addresses findings from the comprehensive review of PR #1 (Phase 1: Project Foundation).

- **Fix FTS5 boolean operator injection** — quote each search token so `AND`/`OR`/`NOT`/`NEAR`/`{}` are treated as literals, not operators
- **Add runtime ChunkType validation** in `rowToChunk` — catches invalid types from DB with actionable error
- **Add JSON.parse error context** in `rowToChunk` — corrupted metadata now reports the chunk ID
- **Fix `getDb` singleton** — throws on conflicting `dbPath` instead of silently ignoring it
- **Fix `closeDb` ordering** — nullifies singleton before `.close()` to prevent broken reference on failure
- **Add 5 new tests** (21 → 26 total) covering cross-API deletion isolation, re-upsert FTS/vec consistency, `getChunksByIds` with missing IDs, empty ID list, and empty database search

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm test` — 26/26 tests pass (5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)