### PR TITLE
Archive mcp-server change and sync specs

### DIFF
--- a/openspec/changes/archive/2026-02-16-mcp-server/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-16-mcp-server/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-15

--- a/openspec/changes/archive/2026-02-16-mcp-server/design.md
+++ b/openspec/changes/archive/2026-02-16-mcp-server/design.md
@@ -1,0 +1,51 @@
+## Context
+
+Alexandria's MCP server is the primary interface for LLMs to access indexed API documentation. It sits on top of the database layer and embedder, exposing three tools via the Model Context Protocol over stdio. MCP clients (Claude Desktop, IDEs) launch the server as a child process and communicate via stdin/stdout.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Serve MCP tools over stdio transport (stdin/stdout)
+- Provide three tools: `list-apis`, `search-docs`, `get-api-endpoints`
+- Format results as markdown optimized for LLM consumption
+
+**Non-Goals:**
+- HTTP transport (stdio is simpler and sufficient for local/single-client usage)
+- Authentication/authorization (stdio is inherently local)
+- Caching layer (SQLite reads are fast enough for MVP volumes)
+
+## Decisions
+
+### D1: Stdio transport
+
+**Choice**: Use `@modelcontextprotocol/sdk`'s `StdioServerTransport` for MCP protocol handling over stdin/stdout.
+
+**Alternatives considered**:
+- Streamable HTTP via Express: Adds Express dependency, port management, and network concerns. Overkill for local single-client usage.
+- SSE transport: Deprecated in MCP spec in favor of Streamable HTTP. Not needed for stdio.
+
+**Rationale**: Stdio is the standard MCP transport for local servers. The client spawns the process and communicates directly — no network stack, no port conflicts, no deployment complexity. If HTTP is needed later, it can be added as a separate entry point.
+
+### D2: Three focused tools over a single general-purpose tool
+
+**Choice**: Three separate tools with clear, single-purpose interfaces:
+- `list-apis`: No parameters, returns all indexed APIs
+- `search-docs`: Takes query string + optional apiName + optional types filter
+- `get-api-endpoints`: Takes apiName, returns all endpoint chunks for that API
+
+**Alternatives considered**:
+- Single `query-docs` tool with mode parameter: Overloaded interface, harder for LLMs to use correctly.
+
+**Rationale**: Smaller, focused tools with clear parameter schemas are easier for LLMs to select and call correctly. Each tool maps to a natural question type: "what APIs exist?", "find docs about X", "what endpoints does Y have?".
+
+### D3: Markdown-formatted results
+
+**Choice**: Format all tool results as markdown text, not JSON.
+
+**Rationale**: LLMs consume markdown naturally. Structured markdown (headers, lists, code blocks) gives the model clear context without requiring JSON parsing. This is how LLMs prefer to receive reference material.
+
+## Risks / Trade-offs
+
+- **Single client** → Stdio supports one connected client at a time. Mitigation: This is the standard MCP model. Multiple clients each spawn their own server process.
+- **Embedding at query time** → `search-docs` needs to embed the query string via Voyage AI on each call, adding latency (~100-200ms). Mitigation: Acceptable for interactive use. Could add embedding cache later if needed.
+- **No pagination** → Tools return all matching results up to the limit. Mitigation: Default limit of 20 is reasonable for LLM consumption. LLMs typically need a focused set of results, not pages.

--- a/openspec/changes/archive/2026-02-16-mcp-server/proposal.md
+++ b/openspec/changes/archive/2026-02-16-mcp-server/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The indexed documentation needs to be accessible to LLMs via a standard protocol. An MCP server over stdio allows any MCP-compatible client (Claude Desktop, IDEs, custom agents) to search and browse API documentation without direct database access.
+
+## What Changes
+
+- MCP server using stdio transport (stdin/stdout), launched as a child process by MCP clients
+- Three MCP tools: `list-apis`, `search-docs`, `get-api-endpoints`
+- Markdown-formatted results optimized for LLM consumption
+
+## Capabilities
+
+### New Capabilities
+
+- `mcp-serving`: MCP server over stdio exposing documentation search tools. Provides `list-apis` (enumerate indexed APIs), `search-docs` (hybrid search with optional filters), and `get-api-endpoints` (list all endpoints for a named API). Results formatted as markdown for LLM readability.
+
+### Modified Capabilities
+
+(none)
+
+## Impact
+
+- **Code**: Creates `src/server/index.ts`, `src/server/tools/list-apis.ts`, `src/server/tools/search-docs.ts`, `src/server/tools/get-api-endpoints.ts`
+- **Dependencies**: Uses `@modelcontextprotocol/sdk` (already in package.json). Imports from db layer (Change 1) and embedder (Change 4).
+- **npm scripts**: The `dev:server` script runs this server via `node`/`tsx`

--- a/openspec/changes/archive/2026-02-16-mcp-server/specs/mcp-serving/spec.md
+++ b/openspec/changes/archive/2026-02-16-mcp-server/specs/mcp-serving/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: MCP server over stdio
+
+The system SHALL provide an MCP server that communicates via `StdioServerTransport` from `@modelcontextprotocol/sdk`, reading JSON-RPC messages from stdin and writing responses to stdout. The server SHALL initialize the database connection on startup.
+
+#### Scenario: Server starts and accepts MCP requests
+
+- **WHEN** the server process is started by an MCP client
+- **THEN** it SHALL connect stdio transport and accept MCP requests via stdin/stdout
+
+### Requirement: list-apis tool
+
+The server SHALL register an MCP tool named `list-apis` that takes no parameters and returns a markdown-formatted list of all indexed APIs with their names and versions.
+
+#### Scenario: List APIs with indexed data
+
+- **WHEN** `list-apis` is called and the database contains 3 indexed APIs
+- **THEN** it SHALL return a markdown list with each API's name and version
+
+#### Scenario: No APIs indexed
+
+- **WHEN** `list-apis` is called and the database is empty
+- **THEN** it SHALL return a message indicating no APIs are indexed
+
+### Requirement: search-docs tool
+
+The server SHALL register an MCP tool named `search-docs` that accepts a required `query` string parameter and optional `apiName` and `types` filter parameters. It SHALL embed the query via Voyage AI, run hybrid search, and return results formatted as markdown.
+
+#### Scenario: Search with query only
+
+- **WHEN** `search-docs` is called with `query: "authentication flow"`
+- **THEN** it SHALL embed the query, run hybrid search across all APIs, and return matching chunks as markdown with titles, types, and content
+
+#### Scenario: Search with API filter
+
+- **WHEN** `search-docs` is called with `query: "create user"` and `apiName: "users-api"`
+- **THEN** it SHALL only return results from the `users-api` API
+
+#### Scenario: Search with type filter
+
+- **WHEN** `search-docs` is called with `query: "payment"` and `types: ["endpoint"]`
+- **THEN** it SHALL only return endpoint-type chunks
+
+#### Scenario: No results found
+
+- **WHEN** `search-docs` is called with a query that matches nothing
+- **THEN** it SHALL return a message indicating no results were found
+
+### Requirement: get-api-endpoints tool
+
+The server SHALL register an MCP tool named `get-api-endpoints` that accepts a required `apiName` string parameter and returns all endpoint chunks for that API formatted as a markdown list with method, path, and summary.
+
+#### Scenario: List endpoints for existing API
+
+- **WHEN** `get-api-endpoints` is called with `apiName: "payments"`
+- **THEN** it SHALL return all endpoint chunks for the payments API as a markdown list showing HTTP method, path, and summary for each
+
+#### Scenario: API not found
+
+- **WHEN** `get-api-endpoints` is called with an `apiName` that doesn't exist in the database
+- **THEN** it SHALL return a message indicating the API was not found
+
+### Requirement: Markdown result formatting
+
+All tool results SHALL be formatted as markdown optimized for LLM consumption. Search results SHALL include chunk title, type badge, API name, and content. Endpoint listings SHALL include method, path, and summary.
+
+#### Scenario: Search result format
+
+- **WHEN** search results are returned
+- **THEN** each result SHALL be formatted with a heading (chunk title), a type indicator, the API source, and the chunk content as markdown
+
+#### Scenario: Endpoint list format
+
+- **WHEN** endpoint chunks are listed
+- **THEN** each endpoint SHALL show its HTTP method (uppercased), path, and summary/description in a scannable format

--- a/openspec/changes/archive/2026-02-16-mcp-server/tasks.md
+++ b/openspec/changes/archive/2026-02-16-mcp-server/tasks.md
@@ -1,0 +1,23 @@
+## 1. Server Setup
+
+- [x] 1.1 Create `src/server/index.ts` with MCP `Server` and `StdioServerTransport`, initialize database connection on startup
+- [x] 1.2 Register tool definitions (JSON Schema for each tool's parameters)
+
+## 2. MCP Tools
+
+- [x] 2.1 Create `src/server/tools/list-apis.ts` — query apis table, format as markdown list with name and version
+- [x] 2.2 Create `src/server/tools/search-docs.ts` — accept query + optional apiName/types, embed query via Voyage, run hybrid search, format results as markdown
+- [x] 2.3 Create `src/server/tools/get-api-endpoints.ts` — accept apiName, look up API by name, fetch endpoint chunks, format as markdown list with method/path/summary
+
+## 3. Result Formatting
+
+- [x] 3.1 Implement markdown formatting for search results (title, type badge, API name, content)
+- [x] 3.2 Implement markdown formatting for endpoint listings (method, path, summary)
+- [x] 3.3 Implement empty-state messages ("No APIs indexed", "No results found", "API not found")
+
+## 4. Verification
+
+- [x] 4.1 Start server via stdio, confirm it accepts MCP `initialize` handshake
+- [x] 4.2 Call `list-apis`, verify it returns indexed APIs
+- [x] 4.3 Call `search-docs` with a natural language query, verify relevant results
+- [x] 4.4 Call `get-api-endpoints` with an API name, verify endpoint listing

--- a/openspec/specs/mcp-serving/spec.md
+++ b/openspec/specs/mcp-serving/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: MCP server over stdio
+
+The system SHALL provide an MCP server that communicates via `StdioServerTransport` from `@modelcontextprotocol/sdk`, reading JSON-RPC messages from stdin and writing responses to stdout. The server SHALL initialize the database connection on startup.
+
+#### Scenario: Server starts and accepts MCP requests
+
+- **WHEN** the server process is started by an MCP client
+- **THEN** it SHALL connect stdio transport and accept MCP requests via stdin/stdout
+
+### Requirement: list-apis tool
+
+The server SHALL register an MCP tool named `list-apis` that takes no parameters and returns a markdown-formatted list of all indexed APIs with their names and versions.
+
+#### Scenario: List APIs with indexed data
+
+- **WHEN** `list-apis` is called and the database contains 3 indexed APIs
+- **THEN** it SHALL return a markdown list with each API's name and version
+
+#### Scenario: No APIs indexed
+
+- **WHEN** `list-apis` is called and the database is empty
+- **THEN** it SHALL return a message indicating no APIs are indexed
+
+### Requirement: search-docs tool
+
+The server SHALL register an MCP tool named `search-docs` that accepts a required `query` string parameter and optional `apiName` and `types` filter parameters. It SHALL embed the query via Voyage AI, run hybrid search, and return results formatted as markdown.
+
+#### Scenario: Search with query only
+
+- **WHEN** `search-docs` is called with `query: "authentication flow"`
+- **THEN** it SHALL embed the query, run hybrid search across all APIs, and return matching chunks as markdown with titles, types, and content
+
+#### Scenario: Search with API filter
+
+- **WHEN** `search-docs` is called with `query: "create user"` and `apiName: "users-api"`
+- **THEN** it SHALL only return results from the `users-api` API
+
+#### Scenario: Search with type filter
+
+- **WHEN** `search-docs` is called with `query: "payment"` and `types: ["endpoint"]`
+- **THEN** it SHALL only return endpoint-type chunks
+
+#### Scenario: No results found
+
+- **WHEN** `search-docs` is called with a query that matches nothing
+- **THEN** it SHALL return a message indicating no results were found
+
+### Requirement: get-api-endpoints tool
+
+The server SHALL register an MCP tool named `get-api-endpoints` that accepts a required `apiName` string parameter and returns all endpoint chunks for that API formatted as a markdown list with method, path, and summary.
+
+#### Scenario: List endpoints for existing API
+
+- **WHEN** `get-api-endpoints` is called with `apiName: "payments"`
+- **THEN** it SHALL return all endpoint chunks for the payments API as a markdown list showing HTTP method, path, and summary for each
+
+#### Scenario: API not found
+
+- **WHEN** `get-api-endpoints` is called with an `apiName` that doesn't exist in the database
+- **THEN** it SHALL return a message indicating the API was not found
+
+### Requirement: Markdown result formatting
+
+All tool results SHALL be formatted as markdown optimized for LLM consumption. Search results SHALL include chunk title, type badge, API name, and content. Endpoint listings SHALL include method, path, and summary.
+
+#### Scenario: Search result format
+
+- **WHEN** search results are returned
+- **THEN** each result SHALL be formatted with a heading (chunk title), a type indicator, the API source, and the chunk content as markdown
+
+#### Scenario: Endpoint list format
+
+- **WHEN** endpoint chunks are listed
+- **THEN** each endpoint SHALL show its HTTP method (uppercased), path, and summary/description in a scannable format


### PR DESCRIPTION
## Summary\n\n- Archive completed `mcp-server` OpenSpec change to `archive/2026-02-16-mcp-server/`\n- Sync `mcp-serving` delta spec to main specs\n- Mark all tasks as complete\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)