### PR TITLE
Switch ollama and transformers defaults to BGE-large

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,18 +4,18 @@ ALEXANDRIA_DB_PATH=./alexandria.db
 # Embedding provider: voyage (default), ollama, transformers
 # Each provider has a default embedding dimension:
 #   voyage      → 1024d (voyage-3-lite)
-#   ollama      → 768d  (nomic-embed-text)
-#   transformers → 384d  (Xenova/all-MiniLM-L6-v2)
+#   ollama      → 1024d (bge-large)
+#   transformers → 1024d (Xenova/bge-large-en-v1.5)
 # Switching providers requires re-indexing: npm run ingest -- --all
 EMBEDDING_PROVIDER=transformers
 
 # Ollama settings (when EMBEDDING_PROVIDER=ollama)
 OLLAMA_URL=http://localhost:11434
-OLLAMA_MODEL=nomic-embed-text
+OLLAMA_MODEL=bge-large
 # Must match the model's actual dimension. Override if using a non-default model.
-OLLAMA_DIMENSION=768
+OLLAMA_DIMENSION=1024
 
 # Transformers.js settings (when EMBEDDING_PROVIDER=transformers)
-TRANSFORMERS_MODEL=Xenova/all-MiniLM-L6-v2
+TRANSFORMERS_MODEL=Xenova/bge-large-en-v1.5
 # Must match the model's actual dimension. Override if using a non-default model.
-TRANSFORMERS_DIMENSION=384
+TRANSFORMERS_DIMENSION=1024

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,8 @@ src/
       types.ts             — EmbeddingProvider interface (dimension, embedDocuments, embedQuery)
       index.ts             — Provider singleton factory (reads EMBEDDING_PROVIDER env var)
       voyage.ts            — Voyage AI provider (voyage-3-lite, 1024d, 128/batch)
-      ollama.ts            — Ollama provider (nomic-embed-text, 768d)
-      transformers.ts      — HF Transformers provider (all-MiniLM-L6-v2, 384d, local)
+      ollama.ts            — Ollama provider (bge-large, 1024d)
+      transformers.ts      — HF Transformers provider (bge-large-en-v1.5, 1024d, local)
   server/
     index.ts               — MCP server over stdio (StdioServerTransport)
     format.ts              — Response formatters (API list, search results, endpoints)
@@ -62,12 +62,12 @@ VOYAGE_API_KEY=...                 # Required
 
 # Ollama (when EMBEDDING_PROVIDER=ollama)
 OLLAMA_URL=http://localhost:11434  # Optional, default shown
-OLLAMA_MODEL=nomic-embed-text     # Optional, default shown
-OLLAMA_DIMENSION=768               # Optional, default shown
+OLLAMA_MODEL=bge-large             # Optional, default shown
+OLLAMA_DIMENSION=1024              # Optional, default shown
 
 # Transformers (when EMBEDDING_PROVIDER=transformers)
-TRANSFORMERS_MODEL=Xenova/all-MiniLM-L6-v2  # Optional, default shown
-TRANSFORMERS_DIMENSION=384                    # Optional, default shown
+TRANSFORMERS_MODEL=Xenova/bge-large-en-v1.5  # Optional, default shown
+TRANSFORMERS_DIMENSION=1024                   # Optional, default shown
 ```
 
 ## Key Patterns

--- a/src/ingestion/__tests__/ollama-provider.test.ts
+++ b/src/ingestion/__tests__/ollama-provider.test.ts
@@ -29,7 +29,7 @@ describe('OllamaProvider', () => {
     expect(mockFetch).toHaveBeenCalledOnce();
     expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:11434/api/embed');
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body.model).toBe('nomic-embed-text');
+    expect(body.model).toBe('bge-large');
     expect(body.input).toEqual(['hello', 'world']);
 
     expect(results).toHaveLength(2);
@@ -115,9 +115,9 @@ describe('OllamaProvider', () => {
     expect(provider.dimension).toBe(1536);
   });
 
-  it('defaults dimension to 768', () => {
+  it('defaults dimension to 1024', () => {
     const provider = new OllamaProvider();
-    expect(provider.dimension).toBe(768);
+    expect(provider.dimension).toBe(1024);
   });
 
   it('throws when API returns wrong number of embeddings', async () => {

--- a/src/ingestion/__tests__/transformers-provider.test.ts
+++ b/src/ingestion/__tests__/transformers-provider.test.ts
@@ -45,10 +45,10 @@ describe('TransformersProvider', () => {
 
     expect(mockPipelineFn).toHaveBeenCalledWith(
       'feature-extraction',
-      'Xenova/all-MiniLM-L6-v2',
+      'Xenova/bge-large-en-v1.5',
     );
     expect(mockPipeline).toHaveBeenCalledWith(['hello', 'world'], {
-      pooling: 'mean',
+      pooling: 'cls',
       normalize: true,
     });
     expect(results).toHaveLength(2);
@@ -105,7 +105,7 @@ describe('TransformersProvider', () => {
     const provider = await createProvider();
 
     await expect(provider.embedDocuments(['test'])).rejects.toThrow(
-      'Failed to load Transformers model "Xenova/all-MiniLM-L6-v2": network timeout',
+      'Failed to load Transformers model "Xenova/bge-large-en-v1.5": network timeout',
     );
   });
 
@@ -131,9 +131,9 @@ describe('TransformersProvider', () => {
     expect(provider.dimension).toBe(768);
   });
 
-  it('defaults dimension to 384', async () => {
+  it('defaults dimension to 1024', async () => {
     const provider = await createProvider();
-    expect(provider.dimension).toBe(384);
+    expect(provider.dimension).toBe(1024);
   });
 
   it('throws descriptive error when inference fails', async () => {

--- a/src/ingestion/providers/ollama.ts
+++ b/src/ingestion/providers/ollama.ts
@@ -1,8 +1,8 @@
 import type { EmbeddingProvider } from './types.js';
 
 const DEFAULT_URL = 'http://localhost:11434';
-const DEFAULT_MODEL = 'nomic-embed-text';
-const DEFAULT_DIMENSION = 768;
+const DEFAULT_MODEL = 'bge-large';
+const DEFAULT_DIMENSION = 1024;
 
 export class OllamaProvider implements EmbeddingProvider {
   readonly dimension: number;

--- a/src/ingestion/providers/transformers.ts
+++ b/src/ingestion/providers/transformers.ts
@@ -4,8 +4,8 @@ import {
 } from '@huggingface/transformers';
 import type { EmbeddingProvider } from './types.js';
 
-const DEFAULT_MODEL = 'Xenova/all-MiniLM-L6-v2';
-const DEFAULT_DIMENSION = 384;
+const DEFAULT_MODEL = 'Xenova/bge-large-en-v1.5';
+const DEFAULT_DIMENSION = 1024;
 
 export class TransformersProvider implements EmbeddingProvider {
   readonly dimension: number;
@@ -41,7 +41,7 @@ export class TransformersProvider implements EmbeddingProvider {
 
     let output: { tolist(): number[][] };
     try {
-      output = await pipe(texts, { pooling: 'mean', normalize: true });
+      output = await pipe(texts, { pooling: 'cls', normalize: true });
     } catch (error) {
       throw new Error(
         `Transformers inference failed: ${error instanceof Error ? error.message : error}`,


### PR DESCRIPTION
## Summary
- Default embedding model for **Ollama** changed from `nomic-embed-text` (768d) to `bge-large` (1024d)
- Default embedding model for **Transformers** changed from `Xenova/all-MiniLM-L6-v2` (384d) to `Xenova/bge-large-en-v1.5` (1024d)
- Transformers pooling strategy updated from `mean` to `cls` to match BGE model requirements
- All three providers now share the same 1024d dimension, simplifying provider switching

## Test plan
- [x] All 168 existing tests pass
- [ ] Pull `bge-large` in Ollama (`ollama pull bge-large`) and verify ingestion
- [ ] Verify Transformers provider downloads and runs `Xenova/bge-large-en-v1.5`
- [ ] Re-ingest with `npm run ingest -- --all` after switching

🤖 Generated with [Claude Code](https://claude.com/claude-code)