### PR TITLE
Add configurable pooling and fix flaky test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,5 @@ OLLAMA_DIMENSION=1024
 TRANSFORMERS_MODEL=Xenova/bge-large-en-v1.5
 # Must match the model's actual dimension. Override if using a non-default model.
 TRANSFORMERS_DIMENSION=1024
+# Pooling strategy: cls (BGE models) or mean (MiniLM, etc.). Must match the model.
+TRANSFORMERS_POOLING=cls

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ OLLAMA_DIMENSION=1024              # Optional, default shown
 # Transformers (when EMBEDDING_PROVIDER=transformers)
 TRANSFORMERS_MODEL=Xenova/bge-large-en-v1.5  # Optional, default shown
 TRANSFORMERS_DIMENSION=1024                   # Optional, default shown
+TRANSFORMERS_POOLING=cls                      # Optional, cls (BGE) or mean (MiniLM)
 ```
 
 ## Key Patterns

--- a/README.md
+++ b/README.md
@@ -126,6 +126,38 @@ Add to `.vscode/mcp.json` in the workspace root:
 | `npm run format`       | Prettier (write)                                                 |
 | `npm run format:check` | Prettier (check only)                                            |
 
+## Advanced
+
+### Custom embedding models
+
+The Ollama and Transformers providers can use any compatible embedding model. Set the model, dimension, and (for Transformers) pooling strategy via environment variables in `.env`:
+
+**Ollama** — any model from the [Ollama library](https://ollama.com/library) that supports embeddings:
+
+```bash
+OLLAMA_MODEL=bge-large           # default
+OLLAMA_DIMENSION=1024            # must match the model's output dimension
+```
+
+**Transformers.js** — any ONNX model from HuggingFace (typically under the `Xenova/` namespace):
+
+```bash
+TRANSFORMERS_MODEL=Xenova/bge-large-en-v1.5   # default
+TRANSFORMERS_DIMENSION=1024                    # must match the model's output dimension
+TRANSFORMERS_POOLING=cls                       # cls (BGE models) or mean (MiniLM, etc.)
+```
+
+Example — switching to MiniLM for a lighter local setup:
+
+```bash
+EMBEDDING_PROVIDER=transformers
+TRANSFORMERS_MODEL=Xenova/all-MiniLM-L6-v2
+TRANSFORMERS_DIMENSION=384
+TRANSFORMERS_POOLING=mean
+```
+
+After changing the model or provider, re-index: `npm run ingest -- --all`.
+
 ## Project Status
 
 | Phase                                                        | Status |

--- a/src/ingestion/__tests__/markdown-parser.test.ts
+++ b/src/ingestion/__tests__/markdown-parser.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { resolve, dirname } from 'node:path';
+import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { writeFile, unlink } from 'node:fs/promises';
+import { writeFile, rm, mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { parseMarkdownFile } from '../markdown-parser.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -100,7 +101,8 @@ describe('parseMarkdownFile', () => {
   });
 
   it('preserves content after h4 headings within parent section', async () => {
-    const tmpPath = resolve(fixturesDir, 'h4-temp-guide.md');
+    const tmpDir = await mkdtemp(join(tmpdir(), 'alexandria-md-'));
+    const tmpPath = resolve(tmpDir, 'h4-temp-guide.md');
     await writeFile(
       tmpPath,
       [
@@ -123,7 +125,7 @@ describe('parseMarkdownFile', () => {
       expect(section!.content).toContain('Sub-detail');
       expect(section!.content).toContain('This should not be lost.');
     } finally {
-      await unlink(tmpPath);
+      await rm(tmpDir, { recursive: true, force: true });
     }
   });
 

--- a/src/ingestion/__tests__/transformers-provider.test.ts
+++ b/src/ingestion/__tests__/transformers-provider.test.ts
@@ -24,6 +24,7 @@ describe('TransformersProvider', () => {
       process.env.TRANSFORMERS_MODEL = originalModel;
     }
     delete process.env.TRANSFORMERS_DIMENSION;
+    delete process.env.TRANSFORMERS_POOLING;
   });
 
   async function createProvider() {
@@ -134,6 +135,22 @@ describe('TransformersProvider', () => {
   it('defaults dimension to 1024', async () => {
     const provider = await createProvider();
     expect(provider.dimension).toBe(1024);
+  });
+
+  it('uses TRANSFORMERS_POOLING env var when set', async () => {
+    process.env.TRANSFORMERS_POOLING = 'mean';
+    mockPipeline.mockResolvedValue({
+      tolist: () => [[0.1, 0.2, 0.3]],
+    });
+    mockPipelineFn.mockResolvedValue(mockPipeline);
+
+    const provider = await createProvider();
+    await provider.embedDocuments(['hello']);
+
+    expect(mockPipeline).toHaveBeenCalledWith(['hello'], {
+      pooling: 'mean',
+      normalize: true,
+    });
   });
 
   it('throws descriptive error when inference fails', async () => {

--- a/src/ingestion/providers/transformers.ts
+++ b/src/ingestion/providers/transformers.ts
@@ -6,6 +6,8 @@ import type { EmbeddingProvider } from './types.js';
 
 const DEFAULT_MODEL = 'Xenova/bge-large-en-v1.5';
 const DEFAULT_DIMENSION = 1024;
+type Pooling = 'cls' | 'mean' | 'none';
+const DEFAULT_POOLING: Pooling = 'cls';
 
 export class TransformersProvider implements EmbeddingProvider {
   readonly dimension: number;
@@ -18,6 +20,10 @@ export class TransformersProvider implements EmbeddingProvider {
 
   private get model(): string {
     return process.env.TRANSFORMERS_MODEL || DEFAULT_MODEL;
+  }
+
+  private get pooling(): Pooling {
+    return (process.env.TRANSFORMERS_POOLING as Pooling) || DEFAULT_POOLING;
   }
 
   private async getPipeline(): Promise<FeatureExtractionPipeline> {
@@ -41,7 +47,7 @@ export class TransformersProvider implements EmbeddingProvider {
 
     let output: { tolist(): number[][] };
     try {
-      output = await pipe(texts, { pooling: 'cls', normalize: true });
+      output = await pipe(texts, { pooling: this.pooling, normalize: true });
     } catch (error) {
       throw new Error(
         `Transformers inference failed: ${error instanceof Error ? error.message : error}`,


### PR DESCRIPTION
## Summary
- Add `TRANSFORMERS_POOLING` env var (`cls`|`mean`|`none`) so custom models with different pooling strategies work correctly
- Add **Advanced** section to README documenting custom model configuration for Ollama and Transformers
- Fix flaky test: `markdown-parser.test.ts` created a temp `.md` file in the shared fixtures directory, causing parallel ingestion tests to sometimes find 3 files instead of 2

These changes were lost when PR #12 was squash-merged before the final commits were pushed.

## Test plan
- [x] All 169 tests pass (168 + 1 new pooling test)
- [x] Flaky test verified stable across 5 consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)