### PR TITLE
Store raw OpenAPI spec content and serve via get-api-spec tool

### DIFF
--- a/src/db/db.test.ts
+++ b/src/db/db.test.ts
@@ -4,6 +4,7 @@ import { createTestDb } from './index.js';
 import {
   upsertApi,
   getApis,
+  getApiSpecContent,
   upsertChunk,
   deleteChunk,
   deleteChunksByApi,
@@ -102,6 +103,24 @@ describe('API CRUD', () => {
     const apis = getApis(db);
     expect(apis).toHaveLength(1);
     expect(apis[0].version).toBe('3.0');
+  });
+
+  it('should round-trip specContent through upsert and get', () => {
+    const specYaml = 'openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0';
+    upsertApi(db, { ...testApi, specContent: specYaml });
+    const apis = getApis(db);
+    expect(apis[0].specContent).toBe(specYaml);
+  });
+
+  it('should retrieve specContent via getApiSpecContent', () => {
+    const specYaml = 'openapi: 3.0.0\ninfo:\n  title: Test\n  version: 1.0';
+    upsertApi(db, { ...testApi, specContent: specYaml });
+    expect(getApiSpecContent(db, testApi.name)).toBe(specYaml);
+  });
+
+  it('should return undefined from getApiSpecContent when no spec stored', () => {
+    upsertApi(db, { ...testApi, specContent: undefined });
+    expect(getApiSpecContent(db, testApi.name)).toBeUndefined();
   });
 });
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -58,6 +58,13 @@ function initDb(db: Database.Database, dimension: number = 1024): void {
     // Column already exists — ignore
   }
 
+  // Migration: add spec_content column to apis table
+  try {
+    db.exec('ALTER TABLE apis ADD COLUMN spec_content TEXT');
+  } catch {
+    // Column already exists — ignore
+  }
+
   const stored = db
     .prepare("SELECT value FROM config WHERE key = 'embedding_dimension'")
     .get() as { value: string } | undefined;

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -168,12 +168,15 @@ export async function ingestApi(
     chunks.push(...(await parseMarkdownDir(docsPath, id)));
   }
 
+  const specContent = readFileSync(specPath, 'utf-8');
+
   const api: Api = {
     id,
     name,
     specPath: resolve(specPath),
     docsPath: docsPath ? resolve(docsPath) : undefined,
     sourceHash,
+    specContent,
   };
 
   return ingestChunks(name, chunks, api);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -7,6 +7,7 @@ import { registerListApis } from './tools/list-apis.js';
 import { registerSearchApiDocs } from './tools/search-api-docs.js';
 import { registerGetApiEndpoints } from './tools/get-api-endpoints.js';
 import { registerSearchDocs } from './tools/search-docs.js';
+import { registerGetApiSpec } from './tools/get-api-spec.js';
 
 const server = new McpServer({
   name: 'alexandria',
@@ -26,6 +27,7 @@ registerListApis(server, db);
 registerSearchApiDocs(server, db);
 registerGetApiEndpoints(server, db);
 registerSearchDocs(server, db);
+registerGetApiSpec(server, db);
 
 try {
   const transport = new StdioServerTransport();

--- a/src/server/tools/get-api-spec.ts
+++ b/src/server/tools/get-api-spec.ts
@@ -1,0 +1,49 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type Database from 'better-sqlite3';
+import { z } from 'zod';
+import { getApiSpecContent, getApis } from '../../db/queries.js';
+
+export function registerGetApiSpec(server: McpServer, db: Database.Database) {
+  server.registerTool(
+    'get-api-spec',
+    {
+      title: 'Get API Spec',
+      description: 'Return the full raw OpenAPI specification for an API',
+      inputSchema: {
+        apiName: z.string().describe('Name of the API'),
+      },
+    },
+    ({ apiName }) => {
+      try {
+        const api = getApis(db).find((a) => a.name === apiName);
+        if (!api) {
+          return {
+            content: [{ type: 'text', text: `API "${apiName}" not found.` }],
+            isError: true,
+          };
+        }
+
+        const specContent = getApiSpecContent(db, apiName);
+        if (!specContent) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `No spec content stored for "${apiName}".`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        return { content: [{ type: 'text', text: specContent }] };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: 'text', text: `Failed to get spec: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -32,6 +32,7 @@ export interface Api {
   specPath?: string;
   docsPath?: string;
   sourceHash?: string;
+  specContent?: string;
   createdAt?: string;
   updatedAt?: string;
 }


### PR DESCRIPTION
## Summary

- Stores the raw OpenAPI YAML/JSON spec content in the `apis` table (`spec_content` column) during ingestion
- Adds a new `get-api-spec` MCP tool that returns the full authoritative spec for an API by name
- Gives agents access to the complete OpenAPI contract (security definitions, examples, constraints, headers, precise schema structure) that the chunked representation loses

## Test plan

- [x] `npm run build` compiles without errors
- [x] All 212 tests pass (including 6 new tests)
- [x] `npm run lint` clean
- [x] `npm run format:check` clean on changed files
- [ ] Manual: `npm run ingest -- --all --force` then verify `SELECT name, length(spec_content) FROM apis` shows non-null content for API entries
- [ ] Manual: start MCP server, call `get-api-spec` with a known API name, confirm raw YAML is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)